### PR TITLE
support group view

### DIFF
--- a/ui/label_dock.py
+++ b/ui/label_dock.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file '/home/super/PycharmProjects/ISAT_with_segment_anything/ui/label_dock.ui'
+# Form implementation generated from reading ui file 'label_dock.ui'
 #
 # Created by: PyQt5 UI code generator 5.15.7
 #
@@ -27,6 +27,15 @@ class Ui_Form(object):
         self.checkBox_visible = QtWidgets.QCheckBox(self.widget)
         self.checkBox_visible.setObjectName("checkBox_visible")
         self.horizontalLayout.addWidget(self.checkBox_visible)
+        self.comboBox_group_select = QtWidgets.QComboBox(self.widget)
+        self.comboBox_group_select.setObjectName("comboBox_group_select")
+        self.horizontalLayout.addWidget(self.comboBox_group_select)
+        self.button_prev_group = QtWidgets.QPushButton(self.widget)
+        self.button_prev_group.setObjectName("button_prev_group")
+        self.horizontalLayout.addWidget(self.button_prev_group)
+        self.button_next_group = QtWidgets.QPushButton(self.widget)
+        self.button_next_group.setObjectName("button_next_group")
+        self.horizontalLayout.addWidget(self.button_next_group)
         self.verticalLayout.addWidget(self.widget)
         self.listWidget = QtWidgets.QListWidget(Form)
         self.listWidget.setObjectName("listWidget")
@@ -39,3 +48,5 @@ class Ui_Form(object):
         _translate = QtCore.QCoreApplication.translate
         Form.setWindowTitle(_translate("Form", "Form"))
         self.checkBox_visible.setText(_translate("Form", "Visible"))
+        self.button_prev_group.setText(_translate("Form", "Previous"))
+        self.button_next_group.setText(_translate("Form", "Next"))

--- a/ui/label_dock.ui
+++ b/ui/label_dock.ui
@@ -42,6 +42,23 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QComboBox" name="comboBox_group_select"/>
+      </item>
+      <item>
+       <widget class="QPushButton" name="button_prev_group">
+        <property name="text">
+         <string>Previous</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="button_next_group">
+        <property name="text">
+         <string>Next</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/widgets/labels_dock_widget.py
+++ b/widgets/labels_dock_widget.py
@@ -16,6 +16,11 @@ class LabelsDockWidget(QtWidgets.QWidget, Ui_Form):
         self.listWidget.itemSelectionChanged.connect(self.set_polygon_selected)
         self.checkBox_visible.stateChanged.connect(self.set_all_polygon_visible)
 
+        # addded group view
+        self.comboBox_group_select.currentIndexChanged.connect(self.set_group_polygon_visible)
+        self.button_next_group.clicked.connect(self.go_to_next_group)
+        self.button_prev_group.clicked.connect(self.go_to_prev_group)
+
         self.listWidget.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.listWidget.customContextMenuRequested.connect(
             self.right_button_menu)
@@ -75,6 +80,11 @@ class LabelsDockWidget(QtWidgets.QWidget, Ui_Form):
         if self.mainwindow.load_finished:
             self.mainwindow.set_saved_state(False)
 
+        unique_groups = {polygon.group for polygon in self.mainwindow.polygons}
+        self.comboBox_group_select.clear()
+        self.comboBox_group_select.addItem('All')  # add an option to view all groups
+        self.comboBox_group_select.addItems(sorted(unique_groups))
+
     def set_selected(self, polygon):
         item = self.polygon_item_dict[polygon]
         if polygon.isSelected():
@@ -114,3 +124,29 @@ class LabelsDockWidget(QtWidgets.QWidget, Ui_Form):
             check_box = widget.findChild(QtWidgets.QCheckBox, 'check_box')
             check_box.setChecked(visible)
         self.checkBox_visible.setChecked(visible)
+
+    def set_group_polygon_visible(self):
+        selected_group = self.comboBox_group_select.currentText()
+
+        for polygon, item in self.polygon_item_dict.items():
+            widget = self.listWidget.itemWidget(item)
+            check_box = widget.findChild(QtWidgets.QCheckBox, 'check_box')
+
+            if selected_group == 'All' or polygon.group == selected_group:
+                check_box.setChecked(True)
+            else:
+                check_box.setChecked(False)
+
+    def go_to_next_group(self):
+        current_index = self.comboBox_group_select.currentIndex()
+        max_index = self.comboBox_group_select.count() - 1
+        if current_index < max_index:
+            self.comboBox_group_select.setCurrentIndex(current_index + 1)
+            self.set_group_polygon_visible()
+
+    def go_to_prev_group(self):
+        current_index = self.comboBox_group_select.currentIndex()
+        if current_index > 0:
+            self.comboBox_group_select.setCurrentIndex(current_index - 1)
+            self.set_group_polygon_visible()
+

--- a/widgets/labels_dock_widget.py
+++ b/widgets/labels_dock_widget.py
@@ -137,16 +137,34 @@ class LabelsDockWidget(QtWidgets.QWidget, Ui_Form):
             else:
                 check_box.setChecked(False)
 
+    def zoom_to_group(self):
+        selected_group = self.comboBox_group_select.currentText()
+        polygons_in_group = [polygon for polygon, item in self.polygon_item_dict.items() 
+                            if polygon.group == selected_group]
+        if not polygons_in_group:
+            return
+        min_x = min(min(vertex.x() for vertex in polygon.vertexs) for polygon in polygons_in_group)
+        min_y = min(min(vertex.y() for vertex in polygon.vertexs) for polygon in polygons_in_group)
+        max_x = max(max(vertex.x() for vertex in polygon.vertexs) for polygon in polygons_in_group)
+        max_y = max(max(vertex.y() for vertex in polygon.vertexs) for polygon in polygons_in_group)
+        margin = 20
+        bounding_rect = QtCore.QRectF(min_x - margin, min_y - margin, max_x - min_x + 2*margin, max_y - min_y + 2*margin)
+        self.mainwindow.view.fitInView(bounding_rect, QtCore.Qt.KeepAspectRatio)
+
     def go_to_next_group(self):
         current_index = self.comboBox_group_select.currentIndex()
         max_index = self.comboBox_group_select.count() - 1
         if current_index < max_index:
             self.comboBox_group_select.setCurrentIndex(current_index + 1)
             self.set_group_polygon_visible()
+            self.zoom_to_group()
 
     def go_to_prev_group(self):
         current_index = self.comboBox_group_select.currentIndex()
         if current_index > 0:
             self.comboBox_group_select.setCurrentIndex(current_index - 1)
             self.set_group_polygon_visible()
+            self.zoom_to_group()
+
+
 

--- a/widgets/labels_dock_widget.py
+++ b/widgets/labels_dock_widget.py
@@ -4,7 +4,7 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
 from ui.label_dock import Ui_Form
 import functools
-
+import re
 
 class LabelsDockWidget(QtWidgets.QWidget, Ui_Form):
     def __init__(self, mainwindow):
@@ -83,7 +83,7 @@ class LabelsDockWidget(QtWidgets.QWidget, Ui_Form):
         unique_groups = {polygon.group for polygon in self.mainwindow.polygons}
         self.comboBox_group_select.clear()
         self.comboBox_group_select.addItem('All')  # add an option to view all groups
-        self.comboBox_group_select.addItems(sorted(unique_groups))
+        self.comboBox_group_select.addItems(sorted(unique_groups, key=lambda s: [int(text) if text.isdigit() else text.lower() for text in re.split(r'(\d+)', s)]))
 
     def set_selected(self, polygon):
         item = self.polygon_item_dict[polygon]


### PR DESCRIPTION
解决[issue 33](https://github.com/yatengLG/ISAT_with_segment_anything/issues/33)问题，支持同组查看。在菜单中选择初始要查看的组，用`previous`或者`next`查看之前/下一组。

演示：
![Video_2023-07-17_095323](https://github.com/yatengLG/ISAT_with_segment_anything/assets/66273343/cbf2f8b2-1ea0-4788-bc21-dc8f48c4d570)
