### PR TITLE
Update build_sam.py

### DIFF
--- a/ISAT/segment_anything_hq/build_sam.py
+++ b/ISAT/segment_anything_hq/build_sam.py
@@ -89,7 +89,7 @@ def build_sam_vit_t(checkpoint=None):
     mobile_sam.eval()
     if checkpoint is not None:
         with open(checkpoint, "rb") as f:
-            state_dict = torch.load(f)
+            state_dict = torch.load(f) if torch.cuda.is_available() else torch.load(f, map_location=torch.device('cpu'))
         info = mobile_sam.load_state_dict(state_dict, strict=False)
         print(info)
     for n, p in mobile_sam.named_parameters():


### PR DESCRIPTION
修复在没有gpu的设备上报错的问题，报错内容为：
```
Traceback (most recent call last):
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\ISAT\widgets\mainwindow.py", line 151, in init_segment_anything
    self.segany = SegAny(model_path)
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\ISAT\segment_any\segment_any.py", line 51, in __init__
    sam = sam_model_registry[self.model_type](checkpoint=checkpoint)
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\ISAT\segment_anything_hq\build_sam.py", line 92, in build_sam_vit_t
    state_dict = torch.load(f)
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\torch\serialization.py", line 712, in load
    return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\torch\serialization.py", line 1049, in _load
    result = unpickler.load()
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\torch\serialization.py", line 1019, in persistent_load
    load_tensor(dtype, nbytes, key, _maybe_decode_ascii(location))
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\torch\serialization.py", line 1001, in load_tensor
    wrap_storage=restore_location(storage, location),
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\torch\serialization.py", line 175, in default_restore_location
    result = fn(storage, location)
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\torch\serialization.py", line 152, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "D:\Software\Anaconda\envs\isat_env\lib\site-packages\torch\serialization.py", line 136, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```